### PR TITLE
Implement session tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # TRACKER-TOTAL
-ТУТ БУДЕТ ОПИСАНИЕ ВСЕГО 
+
+This project contains a simple session tracker with message storage.
+
+## Features
+- Sessions table stores user sessions with start/end timestamps and a summary.
+- Messages table stores messages linked to a session.
+- Command line interface:
+  - `start_session <telegram_id>` starts a new session.
+  - `message <session_id> <telegram_id> <text>` saves a message.
+  - `end_session <session_id>` ends a session and stores a summary.
+  - `latest_summary <telegram_id>` prints the last session summary.
+
+The summary is generated from the concatenated session messages and trimmed
+for brevity.
+
+Run the tests with `python -m unittest`.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,31 @@
+import os
+import unittest
+from tracker.db import Database
+
+
+class TestDatabase(unittest.TestCase):
+    def setUp(self):
+        self.db_path = 'test.db'
+        # remove file if exists
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        self.db = Database(self.db_path)
+
+    def tearDown(self):
+        self.db.conn.close()
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_session_flow(self):
+        sid = self.db.start_session(123)
+        self.db.store_message(sid, 123, 'hello')
+        self.db.store_message(sid, 123, 'world')
+        summary = self.db.end_session(sid)
+        self.assertTrue(summary)
+        self.assertEqual(self.db.latest_session_summary(123), summary)
+        msgs = self.db.get_session_messages(sid)
+        self.assertEqual(len(msgs), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tracker/__init__.py
+++ b/tracker/__init__.py
@@ -1,0 +1,1 @@
+"""Simple tracker bot modules."""

--- a/tracker/db.py
+++ b/tracker/db.py
@@ -1,0 +1,80 @@
+import sqlite3
+from datetime import datetime
+from typing import List, Optional
+
+from . import summarizer
+
+
+class Database:
+    def __init__(self, path: str = "tracker.db"):
+        self.conn = sqlite3.connect(path)
+        self._setup()
+
+    def _setup(self):
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                telegram_id INTEGER NOT NULL,
+                start_ts TEXT NOT NULL,
+                end_ts TEXT,
+                summary TEXT
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id INTEGER NOT NULL REFERENCES sessions(id),
+                telegram_id INTEGER NOT NULL,
+                content TEXT NOT NULL,
+                ts TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+
+    # Session management
+    def start_session(self, telegram_id: int) -> int:
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO sessions (telegram_id, start_ts) VALUES (?, ?)",
+            (telegram_id, datetime.utcnow().isoformat()),
+        )
+        self.conn.commit()
+        return cur.lastrowid
+
+    def end_session(self, session_id: int) -> str:
+        messages = [row[0] for row in self.conn.execute(
+            "SELECT content FROM messages WHERE session_id = ? ORDER BY ts",
+            (session_id,),
+        ).fetchall()]
+        summary = summarizer.summarize(messages)
+        self.conn.execute(
+            "UPDATE sessions SET end_ts = ?, summary = ? WHERE id = ?",
+            (datetime.utcnow().isoformat(), summary, session_id),
+        )
+        self.conn.commit()
+        return summary
+
+    def latest_session_summary(self, telegram_id: int) -> Optional[str]:
+        row = self.conn.execute(
+            "SELECT summary FROM sessions WHERE telegram_id = ? AND summary IS NOT NULL ORDER BY start_ts DESC LIMIT 1",
+            (telegram_id,),
+        ).fetchone()
+        return row[0] if row else None
+
+    # Message storage
+    def store_message(self, session_id: int, telegram_id: int, content: str) -> None:
+        self.conn.execute(
+            "INSERT INTO messages (session_id, telegram_id, content, ts) VALUES (?, ?, ?, ?)",
+            (session_id, telegram_id, content, datetime.utcnow().isoformat()),
+        )
+        self.conn.commit()
+
+    def get_session_messages(self, session_id: int) -> List[str]:
+        return [row[0] for row in self.conn.execute(
+            "SELECT content FROM messages WHERE session_id = ? ORDER BY ts",
+            (session_id,),
+        ).fetchall()]

--- a/tracker/main.py
+++ b/tracker/main.py
@@ -1,0 +1,62 @@
+import argparse
+from .db import Database
+
+
+def cmd_start(args):
+    db = Database()
+    session_id = db.start_session(args.telegram_id)
+    print(f"Started session {session_id} for user {args.telegram_id}")
+
+
+def cmd_message(args):
+    db = Database()
+    db.store_message(args.session_id, args.telegram_id, args.text)
+    print("Message stored")
+
+
+def cmd_end(args):
+    db = Database()
+    summary = db.end_session(args.session_id)
+    print(f"Session {args.session_id} ended. Summary:\n{summary}")
+
+
+def cmd_latest(args):
+    db = Database()
+    summary = db.latest_session_summary(args.telegram_id)
+    if summary:
+        print(f"Latest summary for {args.telegram_id}: {summary}")
+    else:
+        print("No summary found")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Tracker CLI")
+    sub = parser.add_subparsers()
+
+    p_start = sub.add_parser("start_session")
+    p_start.add_argument("telegram_id", type=int)
+    p_start.set_defaults(func=cmd_start)
+
+    p_msg = sub.add_parser("message")
+    p_msg.add_argument("session_id", type=int)
+    p_msg.add_argument("telegram_id", type=int)
+    p_msg.add_argument("text")
+    p_msg.set_defaults(func=cmd_message)
+
+    p_end = sub.add_parser("end_session")
+    p_end.add_argument("session_id", type=int)
+    p_end.set_defaults(func=cmd_end)
+
+    p_latest = sub.add_parser("latest_summary")
+    p_latest.add_argument("telegram_id", type=int)
+    p_latest.set_defaults(func=cmd_latest)
+
+    args = parser.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tracker/summarizer.py
+++ b/tracker/summarizer.py
@@ -1,0 +1,9 @@
+import textwrap
+
+def summarize(messages):
+    """Return a short summary for a list of messages."""
+    if not messages:
+        return ""
+    text = " ".join(messages)
+    text = textwrap.shorten(text, width=200, placeholder="...")
+    return f"Summary: {text}"


### PR DESCRIPTION
## Summary
- add simple SQLite-based session tracker
- support session summaries
- CLI for starting sessions, storing messages and ending sessions
- provide tests and docs

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_684dc464d9508329a55073a7b6e98d49