### PR TITLE
Migrate to openai v1

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -61,7 +61,7 @@ D — Безопасность: LogicIntegrity | RecursionGuard | FailSafe
 db_lock = threading.Lock()
 
 bot = telebot.TeleBot(TELEGRAM_TOKEN)
-openai.api_key = OPENAI_KEY
+client = openai.OpenAI(api_key=OPENAI_KEY)
 
 conn = None
 
@@ -93,14 +93,14 @@ def start_session(telegram_id: int) -> int:
 
 def summarize_session(dialog: str) -> str:
     try:
-        resp = openai.ChatCompletion.create(
+        resp = client.chat.completions.create(
             model=OPENAI_MODEL,
             messages=[
                 {"role": "system", "content": "Сделай краткий конспект диалога:"},
                 {"role": "user", "content": dialog},
             ],
         )
-        return resp["choices"][0]["message"]["content"].strip()
+        return resp.choices[0].message.content.strip()
     except Exception as e:
         return f"Ошибка суммирования: {e}"
 
@@ -296,8 +296,8 @@ def handle_text(msg):
     update_last(telegram_id, user=True)
     messages, _ = fetch_history(telegram_id)
     try:
-        response = openai.ChatCompletion.create(model=OPENAI_MODEL, messages=messages)
-        reply = response['choices'][0]['message']['content'].strip()
+        response = client.chat.completions.create(model=OPENAI_MODEL, messages=messages)
+        reply = response.choices[0].message.content.strip()
     except Exception as e:
         reply = 'Ошибка LLM: ' + str(e)
     save_msg(session_id, telegram_id, 'assistant', reply)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pytelegrambotapi
-openai
+openai>=1.0.0
 python-dotenv


### PR DESCRIPTION
## Summary
- update Telegram bot to use the `openai>=1.0.0` client
- bump openai requirement to v1

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile bot.py dump_db.py`

------
https://chatgpt.com/codex/tasks/task_e_684dd31619d0832981f3201c8c004ad5