### PR TITLE
Add language change logic to Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # Tracker Total Bot
 
-Skeleton for a Telegram bot powered by OpenAI. Includes a full SQLite schema with
-
-triggers for accounting. Language selection uses inline buttons that vanish
-after choosing.
-
-triggers for accounting.
+Skeleton for a Telegram bot powered by OpenAI. Includes a full SQLite schema
+with triggers for accounting.  Upon `/start` the user selects a language using
+reply buttons.  The language can later be changed from the `/profile` command.
 
 
 See `docs/README.md` for setup instructions.

--- a/bot.py
+++ b/bot.py
@@ -4,6 +4,40 @@ from openai import OpenAI
 from config import TELEGRAM_TOKEN, OPENAI_API_KEY
 from database import init_db, ensure_user, set_language, get_user
 
+# Supported languages and translations for bot messages.  Extend this dict to
+# add new languages.
+MESSAGES = {
+    'en': {
+        'welcome': 'Welcome! 100 bonus credits added.',
+        'choose_lang': 'Choose language',
+        'lang_saved': 'Language saved.',
+        'profile': 'Balance: {balance}\nLanguage: {lang}',
+        'send_start': 'Send /start first.',
+        'change_lang': 'Change language',
+    },
+    'ru': {
+        'welcome': 'Добро пожаловать! 100 бонусных кредитов начислено.',
+        'choose_lang': 'Выберите язык',
+        'lang_saved': 'Язык сохранён.',
+        'profile': 'Баланс: {balance}\nЯзык: {lang}',
+        'send_start': 'Сначала отправьте /start.',
+        'change_lang': 'Сменить язык',
+    },
+}
+
+# Human readable titles of languages for buttons. Keys correspond to language
+# codes in MESSAGES. Modify this dict to expose additional languages in the
+# UI.
+LANG_BUTTONS = {
+    'en': 'English',
+    'ru': 'Русский',
+}
+
+
+def tr(lang: str, key: str) -> str:
+    """Return translated message for language/code pair."""
+    return MESSAGES.get(lang, MESSAGES['en']).get(key, key)
+
 init_db()
 
 bot = telebot.TeleBot(TELEGRAM_TOKEN)
@@ -13,24 +47,26 @@ client = OpenAI(api_key=OPENAI_API_KEY)
 def start(message):
     user, is_new = ensure_user(message.from_user)
     if is_new:
-        bot.send_message(message.chat.id, 'Welcome! 100 bonus credits added.')
+        # Show welcome text in both languages since the user has not chosen
+        # their preferred language yet.
+        welcome = f"{tr('en', 'welcome')} / {tr('ru', 'welcome')}"
+        bot.send_message(message.chat.id, welcome)
 
     markup = types.ReplyKeyboardMarkup(resize_keyboard=True, one_time_keyboard=True)
-    markup.add(types.KeyboardButton('Русский'), types.KeyboardButton('English'))
-    msg = bot.send_message(
-
-        message.chat.id,
-        'Choose language / Выберите язык',
-        reply_markup=markup,
-    )
+    for code, title in LANG_BUTTONS.items():
+        markup.add(types.KeyboardButton(title))
+    prompt = f"{tr('en', 'choose_lang')} / {tr('ru', 'choose_lang')}"
+    msg = bot.send_message(message.chat.id, prompt, reply_markup=markup)
 
     bot.register_next_step_handler(msg, process_lang)
 
 
 def process_lang(message):
-    lang = 'ru' if 'Рус' in message.text else 'en'
+    # Map button title back to language code, default to English.
+    reverse = {v: k for k, v in LANG_BUTTONS.items()}
+    lang = reverse.get(message.text, 'en')
     set_language(message.from_user.id, lang)
-    bot.send_message(message.chat.id, 'Language saved.')
+    bot.send_message(message.chat.id, tr(lang, 'lang_saved'))
 
 
 
@@ -38,11 +74,26 @@ def process_lang(message):
 def profile(message):
     user = get_user(message.from_user.id)
     if not user:
-        bot.reply_to(message, 'Send /start first.')
+        bot.reply_to(message, tr('en', 'send_start'))
         return
-    lang = 'Русский' if user['lang'] == 'ru' else 'English'
-    text = f"Balance: {user['balance']}\nLanguage: {lang}"
-    bot.reply_to(message, text)
+    lang = user['lang']
+    lang_title = LANG_BUTTONS.get(lang, lang)
+    text = tr(lang, 'profile').format(balance=user['balance'], lang=lang_title)
+    markup = types.InlineKeyboardMarkup()
+    markup.add(types.InlineKeyboardButton(tr(lang, 'change_lang'), callback_data='change_lang'))
+    bot.reply_to(message, text, reply_markup=markup)
+
+
+@bot.callback_query_handler(func=lambda call: call.data == 'change_lang')
+def change_lang(call):
+    user = get_user(call.from_user.id)
+    lang = user['lang'] if user else 'en'
+    markup = types.ReplyKeyboardMarkup(resize_keyboard=True, one_time_keyboard=True)
+    for code, title in LANG_BUTTONS.items():
+        markup.add(types.KeyboardButton(title))
+    msg = bot.send_message(call.message.chat.id, tr(lang, 'choose_lang'), reply_markup=markup)
+    bot.register_next_step_handler(msg, process_lang)
+    bot.answer_callback_query(call.id)
 
 @bot.message_handler(func=lambda message: True)
 def echo_all(message):

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,8 @@ The project ships with a SQLite schema providing users, sessions and
 ledger bookkeeping triggers. On first `/start` the bot stores the user,
 
 grants 100 bonus credits and asks to select a language. The `/profile`
-command shows the stored balance and language.
+command shows the stored balance and language.  A language can be changed at
+any time from the profile screen using the *Change language* button.
 
 ## Setup
 1. Copy `.env.example` to `.env` and fill in your keys.


### PR DESCRIPTION
## Summary
- localize bot responses with EN & RU strings
- let user select and change language in profile
- document language change capability

## Testing
- `python -m py_compile bot.py database/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_684efbc53d20832993ee93d4eead1b1b